### PR TITLE
Fix peers display reset bug

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -68,14 +68,15 @@
 				}, 5000);
 			}
 
-			function clearPreviousResults() {
-				stockName.textContent = '';
-				currentPrice.textContent = '';
-				change.textContent = '';
-				peersList.innerHTML = '';
-				errorMessage.textContent = '';
-				resultDiv.style.display = 'none';
-			}
+        function clearPreviousResults() {
+                stockName.textContent = '';
+                currentPrice.textContent = '';
+                change.textContent = '';
+                peersList.innerHTML = '';
+                errorMessage.textContent = '';
+                resultDiv.style.display = 'none';
+                peersDiv.style.display = 'none';
+        }
 
 			form.addEventListener('submit', async (event) => {
 				event.preventDefault();


### PR DESCRIPTION
## Summary
- hide peers section when clearing previous results so stale data isn't displayed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862b4db1fcc8331b6974a74900d0fc6