### PR TITLE
Fix README instructions and repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ This project is a simple stock market checker web application. It allows users t
 ## Setup Instructions
 1. Clone the repository:
    ```bash
-   git clone https://github.com/yourusername/stockmarketchecker.git
-   cd stockmarketchecker
+   git clone https://github.com/yourusername/stock-checker.git
+   cd stock-checker
    ```
 2. Install dependencies:
    ```bash
-   pip install flask
+   pip install -r requirements.txt
    ```
 3. Run the Flask application:
    ```bash
@@ -36,9 +36,19 @@ This project is a simple stock market checker web application. It allows users t
    http://127.0.0.1:5000
    ```
 
+## Environment Variables
+
+Before running the application, make sure to set a `FINNHUB_API_KEY`. The easiest way is to create a `.env` file containing:
+
+```bash
+FINNHUB_API_KEY=your_api_key_here
+```
+
+You can optionally set `FINNHUB_BASE_URL` to override the default endpoint of `https://finnhub.io/api/v1`.
+
 ## Project Structure
 ```
-stockmarketchecker/
+stock-checker/
 ├── static/
 │   └── styles.css         # CSS for styling
 ├── templates/


### PR DESCRIPTION
## Summary
- update repo links from `stockmarketchecker` to `stock-checker`
- install dependencies using `pip install -r requirements.txt`
- document required `FINNHUB_API_KEY` and optional `FINNHUB_BASE_URL`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6862b6eca5048331aa062b76259513b8