### PR TITLE
Fix symbol handling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,7 @@
 
 			async function fetchStockData(symbol) {
 				try {
-					const response = await fetch(`/stock?symbol=${symbol}`);
+                                        const response = await fetch(`/stock?symbol=${encodeURIComponent(symbol)}`);
 					if (!response.ok) {
 						if (response.status === 404) {
 							throw new Error(


### PR DESCRIPTION
## Summary
- encode stock symbol in frontend fetch call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862be020efc83318e76be04f7d201b6