### PR TITLE
Add autocomplete and clickable peers

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,34 @@ def index():
     return render_template("index.html")
 
 
+@app.route("/search")
+def search_symbol():
+    """Return symbol suggestions for autocomplete."""
+    query = request.args.get("query")
+    if not query:
+        return jsonify({"error": "No query provided"}), 400
+
+    try:
+        search_resp = requests.get(
+            f"{BASE_URL}/search",
+            params={"q": query, "token": API_KEY},
+            timeout=10,
+        )
+        search_resp.raise_for_status()
+        data = search_resp.json()
+        results = []
+        for item in data.get("result", [])[:5]:
+            results.append(
+                {
+                    "symbol": item.get("symbol"),
+                    "description": item.get("description"),
+                }
+            )
+        return jsonify({"results": results})
+    except requests.RequestException as err:
+        return jsonify({"error": f"Failed to fetch suggestions: {err}"}), 500
+
+
 @app.route("/stock", methods=["GET"])
 def get_stock_data():
     """

--- a/static/styles.css
+++ b/static/styles.css
@@ -65,17 +65,19 @@ button:hover {
 	list-style: none;
 }
 
-#peers-list li {
-	background-color: #007bff;
-	color: white;
-	padding: 8px 12px;
-	border-radius: 4px;
-	font-size: 14px;
-	transition: background-color 0.3s ease;
+#peers-list button {
+        background-color: #007bff;
+        color: white;
+        padding: 8px 12px;
+        border: none;
+        border-radius: 4px;
+        font-size: 14px;
+        cursor: pointer;
+        transition: background-color 0.3s ease;
 }
 
-#peers-list li:hover {
-	background-color: #0056b3;
+#peers-list button:hover {
+        background-color: #0056b3;
 }
 
 #error-message {
@@ -123,8 +125,8 @@ button:hover {
 		max-width: 250px;
 	}
 
-	#peers-list li {
-		font-size: 12px;
-		padding: 6px 10px;
-	}
+        #peers-list button {
+                font-size: 12px;
+                padding: 6px 10px;
+        }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,13 +10,15 @@
 		<h1>Stock Checker</h1>
 		<form id="stock-form">
 			<label for="symbol">Enter Stock Symbol:</label>
-			<input
-				type="text"
-				id="symbol"
-				name="symbol"
-				required
-				autocomplete="off"
-			/>
+                        <input
+                                type="text"
+                                id="symbol"
+                                name="symbol"
+                                list="suggestions"
+                                required
+                                autocomplete="off"
+                        />
+                        <datalist id="suggestions"></datalist>
 			<button type="submit">Search</button>
 		</form>
 		<div id="loading"></div>
@@ -32,14 +34,16 @@
 		<div class="error" id="error-message"></div>
 		<script>
 			const form = document.getElementById('stock-form');
-			const resultDiv = document.getElementById('result');
-			const peersDiv = document.getElementById('peers');
-			const peersList = document.getElementById('peers-list');
-			const stockName = document.getElementById('stock-name');
-			const currentPrice = document.getElementById('current-price');
-			const change = document.getElementById('change');
-			const loadingSpinner = document.getElementById('loading');
-			const errorMessage = document.getElementById('error-message');
+                        const resultDiv = document.getElementById('result');
+                        const peersDiv = document.getElementById('peers');
+                        const peersList = document.getElementById('peers-list');
+                        const stockName = document.getElementById('stock-name');
+                        const currentPrice = document.getElementById('current-price');
+                        const change = document.getElementById('change');
+                        const loadingSpinner = document.getElementById('loading');
+                        const errorMessage = document.getElementById('error-message');
+                        const suggestions = document.getElementById('suggestions');
+                        const symbolInput = document.getElementById('symbol');
 
 			async function fetchStockData(symbol) {
 				try {
@@ -78,6 +82,39 @@
                 peersDiv.style.display = 'none';
         }
 
+                        async function fetchSuggestions(query) {
+                                try {
+                                        const resp = await fetch(`/search?query=${encodeURIComponent(query)}`);
+                                        if (!resp.ok) {
+                                                return [];
+                                        }
+                                        const data = await resp.json();
+                                        return data.results || [];
+                                } catch (err) {
+                                        console.error('Error fetching suggestions:', err);
+                                        return [];
+                                }
+                        }
+
+                        let suggestionTimeout;
+                        symbolInput.addEventListener('input', async (e) => {
+                                const val = e.target.value.trim();
+                                clearTimeout(suggestionTimeout);
+                                if (val.length < 2) {
+                                        suggestions.innerHTML = '';
+                                        return;
+                                }
+                                suggestionTimeout = setTimeout(async () => {
+                                        const results = await fetchSuggestions(val);
+                                        suggestions.innerHTML = results
+                                                .map(
+                                                        (r) =>
+                                                                `<option value="${r.symbol}">${r.description} (${r.symbol})</option>`
+                                                )
+                                                .join('');
+                                }, 300);
+                        });
+
 			form.addEventListener('submit', async (event) => {
 				event.preventDefault();
 				const symbol = document.getElementById('symbol').value.trim();
@@ -97,29 +134,40 @@
 					change.textContent = `Change: $${data.change} (${data.percent_change}%)`;
 					resultDiv.style.display = 'block';
 
-					// Display peers data
-					if (
-						data.peers &&
-						Array.isArray(data.peers) &&
-						data.peers.length > 0
-					) {
-						const peersHtml = data.peers
-							.map((peer) => `<li>${peer}</li>`)
-							.join('');
-						peersList.innerHTML = peersHtml;
-						peersDiv.style.display = 'block';
-                                                // console.log('Peers list updated:', peersList.innerHTML);
-					} else {
-						peersList.innerHTML = '<li>No related companies available.</li>';
-						peersDiv.style.display = 'block';
-					}
+                                        // Display peers data
+                                        if (
+                                                data.peers &&
+                                                Array.isArray(data.peers) &&
+                                                data.peers.length > 0
+                                        ) {
+                                                const peersHtml = data.peers
+                                                        .map(
+                                                                (peer) =>
+                                                                        `<li><button type="button" class="peer-button" data-symbol="${peer}">${peer}</button></li>`
+                                                        )
+                                                        .join('');
+                                                peersList.innerHTML = peersHtml;
+                                                peersDiv.style.display = 'block';
+                                        } else {
+                                                peersList.innerHTML = '<li>No related companies available.</li>';
+                                                peersDiv.style.display = 'block';
+                                        }
 				} catch (error) {
 					console.error('Error fetching stock data:', error);
 					displayError(error.message);
-				} finally {
-					loadingSpinner.style.display = 'none';
-				}
-			});
-		</script>
-	</body>
+                                } finally {
+                                        loadingSpinner.style.display = 'none';
+                                }
+                        });
+
+                        peersList.addEventListener('click', (event) => {
+                                const button = event.target.closest('.peer-button');
+                                if (button) {
+                                        const sym = button.getAttribute('data-symbol');
+                                        symbolInput.value = sym;
+                                        form.dispatchEvent(new Event('submit'));
+                                }
+                        });
+                </script>
+        </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -70,3 +70,26 @@ def test_get_stock_invalid_symbol():
     assert response.status_code == 404
     data = response.get_json()
     assert 'Invalid stock symbol' in data['error']
+
+
+def test_search_valid_query():
+    client = flask_app.test_client()
+
+    def mock_get(url, params=None, **kwargs):
+        if url.endswith('/search'):
+            return create_mock_response({'result': [{'symbol': 'AAPL', 'description': 'Apple Inc.'}]})
+        else:
+            raise ValueError(f'Unexpected URL {url}')
+
+    with patch('app.requests.get', side_effect=mock_get):
+        response = client.get('/search', query_string={'query': 'apple'})
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['results'][0]['symbol'] == 'AAPL'
+
+
+def test_search_missing_query():
+    client = flask_app.test_client()
+    response = client.get('/search')
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- enable stock symbol suggestions using new `/search` route
- make related companies clickable to fetch their data
- add datalist autocomplete on search box
- test new search endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c2858c1c833192fc2ad20260e710