### PR TITLE
Add company news section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project is a simple stock market checker web application. It allows users t
 - View a list of related companies (peers).
 - Loading spinner while fetching data.
 - Error handling for invalid symbols and network issues.
+- View recent company news.
+- Display quarterly earnings surprises.
 
 ## Requirements
 - Python 3.x

--- a/app.py
+++ b/app.py
@@ -157,5 +157,51 @@ def get_stock_data():
         return jsonify({"error": f"Failed to fetch stock data: {str(e)}"}), 500
 
 
+@app.route("/company-news")
+def company_news():
+    """Return latest company news for a symbol between two dates."""
+    symbol = request.args.get("symbol")
+    from_date = request.args.get("from")
+    to_date = request.args.get("to")
+    if not symbol or not from_date or not to_date:
+        return (
+            jsonify({"error": "symbol, from and to parameters are required"}),
+            400,
+        )
+
+    try:
+        data = cached_get(
+            f"{BASE_URL}/company-news",
+            params={
+                "symbol": symbol,
+                "from": from_date,
+                "to": to_date,
+                "token": API_KEY,
+            },
+        )
+        return jsonify(data)
+    except requests.RequestException as err:
+        return jsonify({"error": f"Failed to fetch company news: {err}"}), 500
+
+
+@app.route("/earnings")
+def earnings_surprises():
+    """Return quarterly earnings surprises for a company."""
+    symbol = request.args.get("symbol")
+    limit = request.args.get("limit")
+    if not symbol:
+        return jsonify({"error": "symbol parameter is required"}), 400
+
+    params = {"symbol": symbol, "token": API_KEY}
+    if limit:
+        params["limit"] = limit
+
+    try:
+        data = cached_get(f"{BASE_URL}/stock/earnings", params=params)
+        return jsonify(data)
+    except requests.RequestException as err:
+        return jsonify({"error": f"Failed to fetch earnings data: {err}"}), 500
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug=True)

--- a/static/styles.css
+++ b/static/styles.css
@@ -164,8 +164,53 @@ input:focus {
         box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
 }
 
+#news {
+        margin-top: 30px;
+        padding: 15px;
+        background: #fafafa;
+        border-radius: 6px;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
+#earnings {
+        margin-top: 30px;
+        padding: 15px;
+        background: #fafafa;
+        border-radius: 6px;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
 #financials h3 {
         color: #005f99;
+}
+
+#news h3 {
+        color: #005f99;
+}
+
+#earnings h3 {
+        color: #005f99;
+}
+
+#earnings-table {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: center;
+}
+
+#earnings-table th,
+#earnings-table td {
+        padding: 6px;
+        border-bottom: 1px solid #e0e0e0;
+}
+
+#news-list {
+        list-style: none;
+        padding: 0;
+}
+
+#news-list li {
+        margin: 6px 0;
 }
 
 #financials-list {

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,14 +47,36 @@
                         <h3>Basic Financials</h3>
                         <ul id="financials-list"></ul>
                 </div>
+                <div id="news" style="display: none">
+                        <h3>Company News</h3>
+                        <ul id="news-list"></ul>
+                </div>
+                <div id="earnings" style="display: none">
+                        <h3>Earnings Surprises</h3>
+                        <table id="earnings-table">
+                                <thead>
+                                        <tr>
+                                                <th>Period</th>
+                                                <th>Actual</th>
+                                                <th>Estimate</th>
+                                                <th>Surprise</th>
+                                        </tr>
+                                </thead>
+                                <tbody id="earnings-body"></tbody>
+                        </table>
+                </div>
                 <div class="error" id="error-message"></div>
-		<script>
-			const form = document.getElementById('stock-form');
+                <script>
+                        const form = document.getElementById('stock-form');
                         const resultDiv = document.getElementById('result');
         const peersDiv = document.getElementById('peers');
         const peersList = document.getElementById('peers-list');
         const financialsDiv = document.getElementById('financials');
         const financialsList = document.getElementById('financials-list');
+        const newsDiv = document.getElementById('news');
+        const newsList = document.getElementById('news-list');
+        const earningsDiv = document.getElementById('earnings');
+        const earningsBody = document.getElementById('earnings-body');
         const marketInfo = document.getElementById('market-info');
         const stockName = document.getElementById('stock-name');
                         const currentPrice = document.getElementById('current-price');
@@ -82,8 +104,8 @@
 
         window.addEventListener('load', fetchMarketStatus);
 
-			async function fetchStockData(symbol) {
-				try {
+                        async function fetchStockData(symbol) {
+                                try {
                                         const response = await fetch(`/stock?symbol=${encodeURIComponent(symbol)}`);
 					if (!response.ok) {
 						if (response.status === 404) {
@@ -96,11 +118,37 @@
 							);
 						}
 					}
-					return await response.json();
-				} catch (error) {
-					throw error;
-				}
-			}
+                                        return await response.json();
+                                } catch (error) {
+                                        throw error;
+                                }
+                        }
+
+        async function fetchCompanyNews(symbol, from, to) {
+                try {
+                        const resp = await fetch(`/company-news?symbol=${encodeURIComponent(symbol)}&from=${from}&to=${to}`);
+                        if (!resp.ok) {
+                                return [];
+                        }
+                        return await resp.json();
+                } catch (err) {
+                        console.error('Error fetching news:', err);
+                        return [];
+                }
+        }
+
+        async function fetchEarnings(symbol, limit = 4) {
+                try {
+                        const resp = await fetch(`/earnings?symbol=${encodeURIComponent(symbol)}&limit=${limit}`);
+                        if (!resp.ok) {
+                                return [];
+                        }
+                        return await resp.json();
+                } catch (err) {
+                        console.error('Error fetching earnings:', err);
+                        return [];
+                }
+        }
 
         function displayError(message) {
                 errorMessage.textContent = message;
@@ -117,13 +165,19 @@
                 change.textContent = '';
                 peersList.innerHTML = '';
                 financialsList.innerHTML = '';
+                newsList.innerHTML = '';
+                earningsBody.innerHTML = '';
                 errorMessage.textContent = '';
                 resultDiv.style.display = 'none';
                 peersDiv.style.display = 'none';
                 financialsDiv.style.display = 'none';
+                newsDiv.style.display = 'none';
+                earningsDiv.style.display = 'none';
                 resultDiv.classList.remove('fade-in');
                 peersDiv.classList.remove('fade-in');
                 financialsDiv.classList.remove('fade-in');
+                newsDiv.classList.remove('fade-in');
+                earningsDiv.classList.remove('fade-in');
         }
 
                         async function fetchSuggestions(query) {
@@ -185,8 +239,8 @@
 				clearPreviousResults();
 				loadingSpinner.style.display = 'block';
 
-				try {
-					const data = await fetchStockData(symbol);
+                                try {
+                                        const data = await fetchStockData(symbol);
                                         // console.log('Response data received:', data);
 
 					// Display stock name and current price
@@ -195,6 +249,39 @@
 					change.textContent = `Change: $${data.change} (${data.percent_change}%)`;
                                         resultDiv.style.display = 'block';
                                         resultDiv.classList.add('fade-in');
+
+                                        const toDate = new Date();
+                                        const toStr = toDate.toISOString().slice(0, 10);
+                                        const fromDate = new Date(toDate);
+                                        fromDate.setMonth(fromDate.getMonth() - 1);
+                                        const fromStr = fromDate.toISOString().slice(0, 10);
+                                        const news = await fetchCompanyNews(symbol, fromStr, toStr);
+                                        if (news && news.length > 0) {
+                                                const newsHtml = news.slice(0, 5)
+                                                        .map(n => `<li><a href="${n.url}" target="_blank" rel="noopener">${n.headline}</a></li>`)
+                                                        .join('');
+                                                newsList.innerHTML = newsHtml;
+                                                newsDiv.style.display = 'block';
+                                                newsDiv.classList.add('fade-in');
+                                        } else {
+                                                newsList.innerHTML = '<li>No recent news available.</li>';
+                                                newsDiv.style.display = 'block';
+                                                newsDiv.classList.add('fade-in');
+                                        }
+
+                                        const earnings = await fetchEarnings(symbol, 4);
+                                        if (earnings && earnings.length > 0) {
+                                                const rows = earnings
+                                                        .map(e => `<tr><td>${e.period}</td><td>${e.actual}</td><td>${e.estimate}</td><td>${e.surprise}</td></tr>`)
+                                                        .join('');
+                                                earningsBody.innerHTML = rows;
+                                                earningsDiv.style.display = 'block';
+                                                earningsDiv.classList.add('fade-in');
+                                        } else {
+                                                earningsBody.innerHTML = '<tr><td colspan="4">No data</td></tr>';
+                                                earningsDiv.style.display = 'block';
+                                                earningsDiv.classList.add('fade-in');
+                                        }
 
                                         // Display peers data
                                         if (

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -113,3 +113,49 @@ def test_market_status():
     assert response.status_code == 200
     data = response.get_json()
     assert data['isOpen'] is True
+
+
+def test_company_news():
+    client = flask_app.test_client()
+
+    def mock_get(url, params=None, **kwargs):
+        if url.endswith('/company-news'):
+            return create_mock_response([
+                {'headline': 'News 1', 'url': 'http://example.com'}
+            ])
+        else:
+            raise ValueError(f'Unexpected URL {url}')
+
+    with patch('app.requests.get', side_effect=mock_get):
+        response = client.get('/company-news', query_string={
+            'symbol': 'AAPL', 'from': '2025-01-01', 'to': '2025-01-31'
+        })
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data[0]['headline'] == 'News 1'
+
+
+def test_earnings():
+    client = flask_app.test_client()
+
+    def mock_get(url, params=None, **kwargs):
+        if url.endswith('/stock/earnings'):
+            return create_mock_response([
+                {
+                    'symbol': 'AAPL',
+                    'period': '2024-12-31',
+                    'actual': 2.1,
+                    'estimate': 2.0,
+                    'surprise': 0.1,
+                }
+            ])
+        else:
+            raise ValueError(f'Unexpected URL {url}')
+
+    with patch('app.requests.get', side_effect=mock_get):
+        response = client.get('/earnings', query_string={'symbol': 'AAPL', 'limit': '1'})
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data[0]['symbol'] == 'AAPL'


### PR DESCRIPTION
## Summary
- add API endpoint `/company-news`
- show latest news on the page
- style new section in CSS
- clear news results on new searches
- test the new API endpoint
- add API endpoint `/earnings`
- display latest earnings surprises on the page
- update features list in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862cf475fe88331983357abbc833dba